### PR TITLE
package send_403_on_failed_login 1.0 hinzugefügt

### DIFF
--- a/sources/send_403_on_failed_login-1.0/description.txt
+++ b/sources/send_403_on_failed_login-1.0/description.txt
@@ -1,0 +1,1 @@
+Send an "HTTP/1.1 403 Forbidden" header on a failed login instead of the default "HTTP/1.1 200 OK"

--- a/sources/send_403_on_failed_login-1.0/license.txt
+++ b/sources/send_403_on_failed_login-1.0/license.txt
@@ -1,0 +1,9 @@
+Copyright (c) 2016, Der Uli im Netz 
+All rights reserved.
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+All advertising materials mentioning features or use of this software must display the following acknowledgement: This product includes software developed by Der Uli and its contributors.
+Neither the name of Der Uli nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/hooks/login_failed.php
+++ b/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/hooks/login_failed.php
@@ -1,2 +1,2 @@
 <?php
-@header('HTTP/1.0 403 Forbidden');
+@header ( 'HTTP/1.0 403 Forbidden' );

--- a/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/hooks/login_failed.php
+++ b/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/hooks/login_failed.php
@@ -1,0 +1,2 @@
+<?php
+@header('HTTP/1.0 403 Forbidden');

--- a/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/main.php
+++ b/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/main.php
@@ -1,4 +1,4 @@
 <?php
-function send_403_on_failed_login_render(){
-   return "";
+function send_403_on_failed_login_render() {
+	return "";
 }

--- a/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/main.php
+++ b/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/main.php
@@ -1,0 +1,4 @@
+<?php
+function send_403_on_failed_login_render(){
+   return "";
+}

--- a/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/metadata.json
+++ b/sources/send_403_on_failed_login-1.0/src/content/modules/send_403_on_failed_login/metadata.json
@@ -1,0 +1,4 @@
+{
+   "version" : "1.0",
+   "embed" : false
+}


### PR DESCRIPTION
Send an "HTTP/1.1 403 Forbidden" header on a failed login instead of the default "HTTP/1.1 200 OK"